### PR TITLE
Run profiler only by request in prod

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -22,7 +22,14 @@ framework:
         with_constructor_extractor: true
 
     profiler:
+        collect: false
+        collect_parameter: profile
         collect_serializer_data: true
+
+when@dev:
+    framework:
+        profiler:
+            collect: true
 
 when@test:
     framework:


### PR DESCRIPTION
Eats about 1GB of disk that's never looked at.

